### PR TITLE
Fix #30

### DIFF
--- a/source/DmapSupport.cpp
+++ b/source/DmapSupport.cpp
@@ -159,7 +159,7 @@ HRESULT GetControllerBaseAddress(PWCHAR deviceName, HANDLE & handle, PVOID & bas
                 devIdStr.append(L"\\0");
                 Platform::String^ devId = ref new Platform::String(devIdStr.c_str());
 
-                create_task(CustomDevice::FromIdAsync(devId, DeviceAccessMode::ReadWrite, DeviceSharingMode::Exclusive))
+                create_task(CustomDevice::FromIdAsync(devId, DeviceAccessMode::ReadWrite, DeviceSharingMode::Shared))
                     .then([&controllerAddress, &handle, &findCompleted, &hr]
                         (CustomDevice^ device)
                 {


### PR DESCRIPTION
This fixes the exception you get when trying to use I2C in shared mode. There may be other implications by moving this from Exclusive to Shared but testing has not surfaced any issues.